### PR TITLE
fixed for invalid derivation result for specific path

### DIFF
--- a/lib/src/utils/ecurve.dart
+++ b/lib/src/utils/ecurve.dart
@@ -105,6 +105,18 @@ Uint8List privateAdd (Uint8List d,Uint8List tweak) {
   BigInt dd = fromBuffer(d);
   BigInt tt = fromBuffer(tweak);
   Uint8List dt = toBuffer((dd + tt) % n);
+
+  if(dt.length < 32) {
+    Uint8List newDt = new Uint8List(32);
+    for(var i = 0; i < 32 - dt.length; i++) {
+      newDt[i] = 0x00;
+    }
+    for(var i = 0; i < dt.length; i++) {
+      newDt[32-dt.length + i] = dt[i];
+    }
+    dt = newDt;
+  }
+
   if (!isPrivate(dt)) return null;
   return dt;
 }


### PR DESCRIPTION
When do 
Uint8List dt = toBuffer((dd + tt) % n);
It will happened the length of dt is smaller than 32.
We have to make sure the length is always 32.