### PR TITLE
Loosen dependency constraints to accept pointycastle 4.0.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,3 +37,6 @@
 
 ## 2.0.0
 - Add null-safety
+
+## 2.0.1
+- Updated pointycastle to allow 4.0.0.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bip32
 description: A BIP32 (https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki) compatible library for Flutter writing by Dart.
-version: 2.0.0
+version: 2.0.1
 homepage: https://github.com/dart-bitcoin/bip32-dart
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
-  pointycastle: ^3.0.1
+  pointycastle: ">=3.0.1 <=4.0.0"
   hex: ^0.2.0
   bs58check: ^1.0.2
 


### PR DESCRIPTION
Hi,
I've updated constraints in dependencies to allow `pointycastle` 4.0.0.
4.0.0 is actively used in other packages so `bip32` package conflicts during `pub get`.
All tests are passing when using 4.0.0.